### PR TITLE
Adds Cargo Departmental Console

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -391,6 +391,9 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 						if((ACCESS_CE in scan.access) && ((target_dept==5) || !target_dept))
 							region_access |= 5
 							get_subordinates("Chief Engineer")
+						if((ACCESS_QM in scan.access) && ((target_dept==6) || !target_dept))
+							region_access |= 6
+							get_subordinates("Quartermaster")
 						if(region_access)
 							authenticated = 1
 			else if ((!( authenticated ) && issilicon(usr)) && (!modify))
@@ -610,7 +613,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 		typed_circuit.target_dept = target_dept
 	else
 		target_dept = typed_circuit.target_dept
-	var/list/dept_list = list("general","security","medical","science","engineering")
+	var/list/dept_list = list("general","security","medical","science","engineering","cargo")
 	name = "[dept_list[target_dept]] department console"
 
 /obj/machinery/computer/card/minor/hos
@@ -631,6 +634,12 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 
 /obj/machinery/computer/card/minor/ce
 	target_dept = 5
+	icon_screen = "idce"
+
+	light_color = LIGHT_COLOR_YELLOW
+
+/obj/machinery/computer/card/minor/qm
+	target_dept = 6
 	icon_screen = "idce"
 
 	light_color = LIGHT_COLOR_YELLOW

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -19,6 +19,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 	var/list/region_access = null
 	var/list/head_subordinates = null
 	var/target_dept = 0 //Which department this computer has access to. 0=all departments
+	// 0=All 1=Service 2=Security 3=Medical 4=Science 5=Engineering 6=Cargo
 
 	//Cooldown for closing positions in seconds
 	//if set to -1: No cooldown... probably a bad idea
@@ -640,6 +641,6 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 
 /obj/machinery/computer/card/minor/qm
 	target_dept = 6
-	icon_screen = "idce"
+	icon_screen = "idce" //Im using the CE one cause idk how to overlay : )
 
 	light_color = LIGHT_COLOR_YELLOW

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -392,9 +392,9 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 						if((ACCESS_CE in scan.access) && ((target_dept==5) || !target_dept))
 							region_access |= 5
 							get_subordinates("Chief Engineer")
-						if((ACCESS_QM in scan.access) && ((target_dept==6) || !target_dept))
-							region_access |= 6
-							get_subordinates("Quartermaster")
+						if((ACCESS_QM in scan.access) && ((target_dept==6) || !target_dept))   //Toolbelt station changes
+							region_access |= 6                                                 //
+							get_subordinates("Quartermaster")                                  //
 						if(region_access)
 							authenticated = 1
 			else if ((!( authenticated ) && issilicon(usr)) && (!modify))
@@ -614,7 +614,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 		typed_circuit.target_dept = target_dept
 	else
 		target_dept = typed_circuit.target_dept
-	var/list/dept_list = list("general","security","medical","science","engineering","cargo")
+	var/list/dept_list = list("general","security","medical","science","engineering","cargo")  //Toolbelt station change
 	name = "[dept_list[target_dept]] department console"
 
 /obj/machinery/computer/card/minor/hos
@@ -639,8 +639,8 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 
 	light_color = LIGHT_COLOR_YELLOW
 
-/obj/machinery/computer/card/minor/qm
-	target_dept = 6
-	icon_screen = "idce" //Im using the CE one cause idk how to overlay : )
-
+/obj/machinery/computer/card/minor/qm                                              //Toolbelt station addition
+	target_dept = 6                                                                //
+	icon_screen = "idce" //Im using the CE one cause idk how to overlay : )        //
+   
 	light_color = LIGHT_COLOR_YELLOW


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the cargo departmental console wich allows the QM to demote his underlings or add access to cargo

## Why It's Good For The Game
The QM is a head in every other aspect it only makes sense for him to be able to demote, also helps in rounds with no Cap/HoP
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added cargo departmental console
:/cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
